### PR TITLE
Less agressive api key checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 *.a
 mkmf.log
 /.idea
+.ruby-version
+.ruby-gemset

--- a/lib/hosted_graphite.rb
+++ b/lib/hosted_graphite.rb
@@ -7,10 +7,11 @@ require 'hosted_graphite/http'
 
 module HostedGraphite
   extend Forwardable
+  extend self
+
   def_delegators :protocol, :send_metric
   module_function :send_metric
-  @@api_key = ENV['HOSTEDGRAPHITE_APIKEY']
-  @@protocol = nil
+  @protocol = nil
 
   class MissingAPIKey < StandardError
     def initialize
@@ -18,27 +19,25 @@ module HostedGraphite
     end
   end
 
-  class << self
-    def api_key
-      @@api_key
-    end
+  def api_key
+    @api_key ||= ENV['HOSTEDGRAPHITE_APIKEY']
+  end
 
-    def api_key=(key)
-      @@api_key = key
-    end
+  def api_key=(key)
+    @api_key = key
+  end
 
-    def protocol
-      @@protocol
-    end
+  def protocol
+    @protocol
+  end
 
-    def protocol=(protocol)
-      case protocol
-        when Class
-          @@protocol = protocol.new
-        when String, Symbol
-          protocol = protocol.to_s.upcase
-          @@protocol = const_get(protocol).new
-      end
+  def protocol=(protocol)
+    case protocol
+      when Class
+        @protocol = protocol.new
+      when String, Symbol
+        protocol   = protocol.to_s.upcase
+        @protocol = const_get(protocol).new
     end
   end
 end

--- a/lib/hosted_graphite/http.rb
+++ b/lib/hosted_graphite/http.rb
@@ -11,7 +11,7 @@ module HostedGraphite
 
     def send_message(message)
       req = Net::HTTP::Post.new(@uri.request_uri)
-      req.basic_auth @api_key, nil
+      req.basic_auth api_key, nil
       req.body = message
       @http.request(req)
     end

--- a/lib/hosted_graphite/protocol.rb
+++ b/lib/hosted_graphite/protocol.rb
@@ -6,13 +6,15 @@ module HostedGraphite
     API_URI = 'https://hostedgraphite.com/api/v1/sink'.freeze
     PORT = 2003.freeze
 
-    def initialize
-      fail MissingAPIKey unless HostedGraphite.api_key
-      @api_key = HostedGraphite.api_key
+    def api_key
+      HostedGraphite.api_key
     end
 
     def send_metric(name, value, timestamp = nil)
+      raise MissingAPIKey unless api_key
       send_message(build_message(name, value, timestamp))
+    rescue MissingAPIKey => e
+      raise e
     rescue => e
       # set HOSTEDGRAPHITE_DEBUG to to raise errors instead of silencing them.
       raise e if ENV['HOSTEDGRAPHITE_DEBUG']

--- a/lib/hosted_graphite/statsd.rb
+++ b/lib/hosted_graphite/statsd.rb
@@ -10,6 +10,7 @@ module HostedGraphite
     PORT = 8125.freeze
 
     def initialize
+      raise MissingAPIKey unless HostedGraphite.api_key
       super(HOST, PORT)
       @namespace = HostedGraphite.api_key
       @prefix    = "#{@namespace}."

--- a/lib/hosted_graphite/statsd.rb
+++ b/lib/hosted_graphite/statsd.rb
@@ -3,15 +3,16 @@ require 'hosted_graphite'
 require 'statsd'
 
 module HostedGraphite
+  def_delegators :statsd, :increment, :decrement, :count, :gauge, :set, :timing, :time
+
   class StatsD < Statsd
     HOST = 'statsd.hostedgraphite.com'.freeze
     PORT = 8125.freeze
 
     def initialize
-      raise MissingAPIKey unless HostedGraphite.api_key
       super(HOST, PORT)
       @namespace = HostedGraphite.api_key
-      @prefix = "#{@namespace}."
+      @prefix    = "#{@namespace}."
     end
 
     private
@@ -24,35 +25,8 @@ module HostedGraphite
     end
   end
 
-  @@statsd = StatsD.new
-
-  class << self
-    def increment(stat, sample_rate=1)
-      @@statsd.increment stat, sample_rate
-    end
-
-    def decrement(stat, sample_rate=1)
-      @@statsd.decrement stat, sample_rate
-    end
-
-    def count(stat, count, sample_rate=1)
-      @@statsd.count stat, count, sample_rate
-    end
-
-    def gauge(stat, value, sample_rate=1)
-      @@statsd.gauge stat, value, sample_rate
-    end
-
-    def set(stat, value, sample_rate=1)
-      @@statsd.set stat, value, sample_rate
-    end
-
-    def timing(stat, ms, sample_rate=1)
-      @@statsd.timing stat, ms, sample_rate
-    end
-
-    def time(stat, sample_rate=1, &blk)
-      @@statsd.time stat, sample_rate, &blk
-    end
+  def statsd
+    @statsd ||= StatsD.new
   end
+
 end

--- a/lib/hosted_graphite/tcp.rb
+++ b/lib/hosted_graphite/tcp.rb
@@ -3,7 +3,7 @@ module HostedGraphite
     private
       def build_message(name, value, timestamp = nil)
         message = [name, value, timestamp].compact.join(' ') + "\n"
-        [@api_key, message].join('.')
+        [api_key, message].join('.')
       end
 
       def send_message(message)

--- a/lib/hosted_graphite/testing.rb
+++ b/lib/hosted_graphite/testing.rb
@@ -1,7 +1,7 @@
 require 'hosted_graphite'
 require 'securerandom'
 module HostedGraphite
-  @@api_key = SecureRandom.hex
+    @api_key = SecureRandom.hex
   [TCP, UDP, HTTP].each do |protocol|
     protocol.class_eval do
 

--- a/lib/hosted_graphite/udp.rb
+++ b/lib/hosted_graphite/udp.rb
@@ -3,7 +3,7 @@ module HostedGraphite
     private
       def build_message(name, value, timestamp = nil)
         message = [name, value, timestamp].compact.join(' ') + "\n"
-        [@api_key, message].join('.')
+        [api_key, message].join('.')
       end
 
       def send_message(message)

--- a/test/test_missing_apikey.rb
+++ b/test/test_missing_apikey.rb
@@ -12,19 +12,19 @@ class MissingAPIKeyTest < Minitest::Test
 
   def test_udp_protocol
     assert_raises HostedGraphite::MissingAPIKey do
-      HostedGraphite::UDP.new
+      HostedGraphite::UDP.new.send_metric('foo', 1)
     end
   end
 
   def test_tcp_protocol
     assert_raises HostedGraphite::MissingAPIKey do
-      HostedGraphite::TCP.new
+      HostedGraphite::TCP.new.send_metric('foo', 1)
     end
   end
 
   def test_http_protocol
     assert_raises HostedGraphite::MissingAPIKey do
-      HostedGraphite::HTTP.new
+      HostedGraphite::HTTP.new.send_metric('foo', 1)
     end
   end
 end


### PR DESCRIPTION
The PR makes it so the API key isn't checked until a stat is actually sent