### PR TITLE
Optional namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ You can also set the hosted graphite API key programatically with:
 HostedGraphite.api_key = 'YOUR API KEY'
 ```
 
+You may also specify a namespace for your metrics, which will be applied if you are using the StatsD backend:
+
+```bash
+HostedGraphite.namespace = 'our_app'
+```
+
 #### Sending a metric via UDP
 ```ruby
 HostedGraphite.protocol = :udp

--- a/lib/hosted_graphite/protocols/statsd.rb
+++ b/lib/hosted_graphite/protocols/statsd.rb
@@ -12,7 +12,11 @@ module HostedGraphite
     def initialize
       raise MissingAPIKey unless HostedGraphite.api_key
       super(HOST, PORT)
-      self.namespace = [HostedGraphite.api_key,HostedGraphite.namespace].join('.')
+      if HostedGraphite.namespace
+        self.namespace = [HostedGraphite.api_key,HostedGraphite.namespace].join('.')
+      else
+        self.namespace = HostedGraphite.api_key
+      end
     end
   end
 

--- a/test/test_stastd.rb
+++ b/test/test_stastd.rb
@@ -28,4 +28,22 @@ class StatsDTest < Minitest::Test
   def test_respond_to_increment
     assert_respond_to HostedGraphite, :increment
   end
+
+  def test_initialize_without_namespace
+    old_namespace = HostedGraphite.namespace
+    HostedGraphite.namespace = nil
+
+    assert_equal HostedGraphite.api_key, HostedGraphite::STATSD.new.namespace
+
+    HostedGraphite.namespace = old_namespace
+  end
+
+  def test_initialize_with
+    old_namespace = HostedGraphite.namespace
+    HostedGraphite.namespace = "foo"
+
+    assert_equal "#{HostedGraphite.api_key}.foo", HostedGraphite::STATSD.new.namespace
+
+    HostedGraphite.namespace = old_namespace
+  end
 end


### PR DESCRIPTION
- Indicate in README that user may provide an optional namespace for use with statsd
- don't expect a namespace exists, otherwise metrics will have an extra period in them

The latter maybe be considered a breaking change, as if there are users of this gem who don't have a namespace configured, their existing metrics will all have the extraneous period.
